### PR TITLE
Upgrades dockwrkr

### DIFF
--- a/scripts/alpine/substance.sh
+++ b/scripts/alpine/substance.sh
@@ -26,5 +26,5 @@ echo "Defaults env_keep += SSH_AUTH_SOCK" >> /etc/sudoers
 echo "substance ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/substance
 
 pip3 install -U pip
-pip3 install git+https://github.com/turbulent/dockwrkr.git@2.0.4
-pip3 install git+https://github.com/turbulent/substance.git@1.1.0
+pip3 install dockwrkr==2.0.7
+pip3 install substance==1.1.0

--- a/substance-base.packer.json
+++ b/substance-base.packer.json
@@ -25,8 +25,7 @@
     "disk_size" : 81920,
 
     "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/x86_64/alpine-virt-3.10.2-x86_64.iso",
-    "iso_checksum": "06eab9a4d3ce28ce31d413b78b6ff94285e432179b6a6cba711e6c6653667567",
-    "iso_checksum_type": "sha256",
+    "iso_checksum": "sha256:06eab9a4d3ce28ce31d413b78b6ff94285e432179b6a6cba711e6c6653667567",
 
     "http_directory" : "support",
     "http_port_min" : 10000,


### PR DESCRIPTION
Includes a fix for an deprecated packer config: `iso_checksum_type`
was dropped in 1.6.0. See https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#160-june-09-2020